### PR TITLE
Fixing the ElasticSearch Output plugin

### DIFF
--- a/app/plugins/common/Common.py
+++ b/app/plugins/common/Common.py
@@ -605,7 +605,7 @@ def Elasticsearch_Main(Object, Title, Plugin_Name, Domain, Link, Result_Type, Ou
         try:
 
             if Elasticsearch_Details[4]:
-                Timestamp = Date(Just_Date=True, Elastic=True)
+                Timestamp = Date(Date_Only=True, Elastic=True)
                 Index = Elasticsearch_Details[3] + "-" + Concat_Plugin_Name + "-" + Timestamp
 
             else:


### PR DESCRIPTION
Hello,
I'm currently aiming to output data from Scrummage to ElasticSearch, you'll find below what I found:
 - The function `Elasticsearch_Main()` calls `Date()` but with a wrong arg name (used Just_Date instead of Only_Date) [FIXED]
 - The Scrummage instance cannot push the data to the index beceause the certificates of the elastic cluster is not truster (to be fixed by users -> add the elastic cert to scrummage server)
 - The default index name in the GUI configuration for the output uses uppercase, which isn't allowed by elastic [TODO] 
 - Sending the request after all these fixes still throw an error : `Common Library - request() missing 1 required positional argument: 'url'.` [TODO]

For your information, my testing environment is a cluster of Docker containers, one for Scrummage and another for Elastic, both linked to the same virtual network.

Hope this will help 😄 